### PR TITLE
SENTRY_AUTH_TOKEN passthrough to run action.

### DIFF
--- a/.github/workflows/ecr.yml
+++ b/.github/workflows/ecr.yml
@@ -40,6 +40,8 @@ jobs:
         uses: aws-actions/amazon-ecr-login@062b18b96a7aff071d4dc91bc00c4c1a7945b076
 
       - name: Upload sourcemap to Sentry
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
         run: |
           npm ci
           npm install tsc -g


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add `SENTRY_AUTH_TOKEN` environment variable to GitHub Actions workflow for Sentry sourcemap upload.
> 
>   - **Environment Variables**:
>     - Added `SENTRY_AUTH_TOKEN` to the `Upload sourcemap to Sentry` step in `.github/workflows/ecr.yml` to enable authentication when uploading sourcemaps.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=dpla%2Fthumbnail-api&utm_source=github&utm_medium=referral)<sup> for f3f138bedd162a6a3204fa39c77d96a02b1cd28b. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->