### PR TITLE
Surface upstream 429 rate-limit errors distinctly in Sentry

### DIFF
--- a/src/ResponseHelper.ts
+++ b/src/ResponseHelper.ts
@@ -29,6 +29,8 @@ export class ResponseHelper {
     });
     if (response.ok) {
       return response;
+    } else if (response.status === 429) {
+      throw new Error(`Rate limited by upstream: ${imageUrl}`);
     } else {
       throw new Error(
         `Failed to read remote image status: ${String(response.status)} ${response.statusText}`,

--- a/test/unit/ResponseHelper.test.ts
+++ b/test/unit/ResponseHelper.test.ts
@@ -118,24 +118,26 @@ describe("ResponseHelper getRemoteImagePromise tests", () => {
     }
   });
 
-  test("getRemoteImagePromise: failure", async () => {
-    const fakeResult = {
-      ok: false,
-      status: 999,
-      statusText: "ohnoes",
-    };
-    const mockFetch = jest.fn(() => Promise.resolve(fakeResult));
+  test.each([
+    [999, "ohnoes", "Failed to read remote image status"],
+    [429, "Too Many Requests", "Rate limited by upstream"],
+  ])(
+    "getRemoteImagePromise: failure with status %d",
+    async (status, statusText, expectedMessage) => {
+      const fakeResult = { ok: false, status, statusText };
+      const mockFetch = jest.fn(() => Promise.resolve(fakeResult));
 
-    expect.assertions(1);
-    try {
-      const responseHelper = new ResponseHelper();
-      global.fetch = mockFetch as unknown as typeof fetch;
-      const imageUrl = "https://example.com/image.jpg";
-      await responseHelper.getRemoteImagePromise(imageUrl);
-    } catch (error: unknown) {
-      expect(error).toBeDefined();
-    } finally {
-      mockFetch.mockRestore();
-    }
-  });
+      expect.assertions(1);
+      try {
+        const responseHelper = new ResponseHelper();
+        global.fetch = mockFetch as unknown as typeof fetch;
+        const imageUrl = "https://example.com/image.jpg";
+        await responseHelper.getRemoteImagePromise(imageUrl);
+      } catch (error: unknown) {
+        expect((error as Error).message).toContain(expectedMessage);
+      } finally {
+        mockFetch.mockRestore();
+      }
+    },
+  );
 });


### PR DESCRIPTION
## Summary

- Adds an explicit `429` branch in `getRemoteImagePromise` that throws `"Rate limited by upstream: <url>"` instead of the generic `"Failed to read remote image status: ..."` message
- Previously, 429 responses from upstream image hosts were indistinguishable from any other non-2xx error in Sentry, making rate-limiting invisible and unactionable
- Unifies the two duplicate `getRemoteImagePromise` failure tests into a single `test.each` covering both the generic failure and 429 cases

## Motivation

When an upstream image host rate-limits the thumbnail-api, the 429 was silently folded into the generic `502` bucket by `translateStatusCode` and logged as `"Couldn't connect to upstream [url]"` — burying the actual cause in the error chain. Sentry had no way to group or alert on rate-limiting specifically.

## Test plan

- [ ] `getRemoteImagePromise: failure with status 429` passes (new test.each case)
- [ ] All existing ResponseHelper tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error messaging for upstream service failures during remote image retrieval. Rate-limited responses now display specific error messages instead of generic failure notifications, helping users identify when operations are throttled by external services.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->