### PR TITLE
Add permissions: contents: read to all workflow files

### DIFF
--- a/.github/workflows/ecr-staging.yml
+++ b/.github/workflows/ecr-staging.yml
@@ -3,8 +3,11 @@ name: "push to ecr: staging"
 on:
   workflow_dispatch:
 
-env: 
+env:
   ECR_REPOSITORY: "thumbnail-api-staging"
+
+permissions:
+  contents: read
 
 jobs:
   ecr:

--- a/.github/workflows/ecr.yml
+++ b/.github/workflows/ecr.yml
@@ -6,6 +6,9 @@ on:
 env: 
   ECR_REPOSITORY: "thumbnail-api"
 
+permissions:
+  contents: read
+
 jobs:
   ecr:
     runs-on: ubuntu-latest

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -9,6 +9,9 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: read
+
 jobs:
   build:
 


### PR DESCRIPTION
## Summary

- Adds `permissions: contents: read` to `ecr.yml`, `ecr-staging.yml`, and `node.js.yml`
- Fixes code scanning alerts #10, #11, #12 — all three workflows were missing explicit permission declarations, which defaults to write-all
- Scoped to read-only as these workflows only need to check out code

## Test plan

- [ ] Confirm code scanning alerts #10, #11, #12 are resolved after merge
- [ ] Verify CI workflow (`node.js.yml`) still passes on a PR after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Strengthened CI/CD security by adding stricter workflow permissions (GITHUB_TOKEN scope set to read-only for repository contents).
  * Minor workflow metadata formatting normalized to improve consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->