### PR TITLE
Fix race condition between fetch timeout and Express response timeout

### DIFF
--- a/src/ExpressSetup.ts
+++ b/src/ExpressSetup.ts
@@ -86,8 +86,10 @@ export class ExpressSetup {
     // eslint happy about the async get handler
     const handler = async (req: express.Request, res: express.Response) => {
       res.setTimeout(RESPONSE_TIMEOUT_MS, () => {
-        res.status(504);
-        res.send("Gateway Timeout");
+        if (res.headersSent || res.writableEnded) {
+          return;
+        }
+        res.status(504).send("Gateway Timeout");
       });
       try {
         await thumbnailApi.handle(req, res);

--- a/src/ExpressSetup.ts
+++ b/src/ExpressSetup.ts
@@ -86,7 +86,11 @@ export class ExpressSetup {
     // eslint happy about the async get handler
     const handler = async (req: express.Request, res: express.Response) => {
       res.setTimeout(RESPONSE_TIMEOUT_MS, () => {
-        if (res.headersSent || res.writableEnded) {
+        if (res.writableEnded) {
+          return;
+        }
+        if (res.headersSent) {
+          res.destroy();
           return;
         }
         res.status(504).send("Gateway Timeout");

--- a/src/ExpressSetup.ts
+++ b/src/ExpressSetup.ts
@@ -5,12 +5,7 @@ import express, { Express } from "express";
 import * as Http from "node:http";
 import { ThumbnailApi } from "./ThumbnailApi";
 import { Server } from "node:http";
-
-// How long we wait for a request from a socket
-const REQUEST_TIMEOUT = 3000; // 3 secs
-
-// How long we wait on piping a response before we give up
-const RESPONSE_TIMEOUT = 10000; // 10 seconds
+import { REQUEST_TIMEOUT_MS, RESPONSE_TIMEOUT_MS } from "./timeoutConfig";
 
 export class ExpressSetup {
   app: Express;
@@ -77,7 +72,7 @@ export class ExpressSetup {
   }
 
   setRequestTimeout(server: Http.Server) {
-    server.requestTimeout = REQUEST_TIMEOUT;
+    server.requestTimeout = REQUEST_TIMEOUT_MS;
   }
 
   server(port: number): Http.Server {
@@ -90,7 +85,7 @@ export class ExpressSetup {
     // next two methods are like this to make
     // eslint happy about the async get handler
     const handler = async (req: express.Request, res: express.Response) => {
-      res.setTimeout(RESPONSE_TIMEOUT, () => {
+      res.setTimeout(RESPONSE_TIMEOUT_MS, () => {
         res.status(504);
         res.send("Gateway Timeout");
       });

--- a/src/ResponseHelper.ts
+++ b/src/ResponseHelper.ts
@@ -6,7 +6,9 @@ import { getLogger } from "./logger";
 const logger = getLogger();
 
 export class ResponseHelper {
-  FETCH_TIMEOUT = 10 * 1000; // 10 seconds;
+  // Must be well under RESPONSE_TIMEOUT (10s) in ExpressSetup so that AbortSignal fires
+  // and sendError(404) completes before res.setTimeout sends a 504, preventing ERR_HTTP_HEADERS_SENT.
+  FETCH_TIMEOUT = 5 * 1000; // 5 seconds
 
   async pipe(body: ReadableStream, expressResponse: express.Response): Promise<void> {
     try {
@@ -99,7 +101,7 @@ export class ResponseHelper {
   // whereas s3 responses should live there for a long time
   // see LONG_CACHE_TIME and SHORT_CACHE_TIME, above
   getCacheHeaders(seconds: number): Map<string, string> {
-    const now = new Date().getTime();
+    const now = Date.now();
     const expirationDateString = new Date(now + 1000 * seconds).toUTCString();
     const cacheControl = `public, max-age=${String(seconds)}`;
     return new Map([

--- a/src/ResponseHelper.ts
+++ b/src/ResponseHelper.ts
@@ -2,13 +2,12 @@ import { Readable } from "stream";
 import { pipeline } from "stream/promises";
 import express from "express";
 import { getLogger } from "./logger";
+import { FETCH_TIMEOUT_MS } from "./timeoutConfig";
 
 const logger = getLogger();
 
 export class ResponseHelper {
-  // Must be well under RESPONSE_TIMEOUT (10s) in ExpressSetup so that AbortSignal fires
-  // and sendError(404) completes before res.setTimeout sends a 504, preventing ERR_HTTP_HEADERS_SENT.
-  FETCH_TIMEOUT = 5 * 1000; // 5 seconds
+  FETCH_TIMEOUT = FETCH_TIMEOUT_MS;
 
   async pipe(body: ReadableStream, expressResponse: express.Response): Promise<void> {
     try {

--- a/src/timeoutConfig.ts
+++ b/src/timeoutConfig.ts
@@ -1,0 +1,11 @@
+// REQUEST_TIMEOUT: how long we wait for a request from a socket
+export const REQUEST_TIMEOUT_MS = 3_000;
+
+// RESPONSE_TIMEOUT: how long before Express gives up on the full response
+export const RESPONSE_TIMEOUT_MS = 10_000;
+
+// FETCH_TIMEOUT: how long to wait on an upstream image fetch.
+// Must be well under RESPONSE_TIMEOUT_MS so that AbortSignal fires and
+// sendError(404) completes before res.setTimeout sends a 504,
+// preventing ERR_HTTP_HEADERS_SENT.
+export const FETCH_TIMEOUT_MS = 5_000;

--- a/src/timeoutConfig.ts
+++ b/src/timeoutConfig.ts
@@ -9,3 +9,9 @@ export const RESPONSE_TIMEOUT_MS = 10_000;
 // sendError(404) completes before res.setTimeout sends a 504,
 // preventing ERR_HTTP_HEADERS_SENT.
 export const FETCH_TIMEOUT_MS = 5_000;
+
+if (FETCH_TIMEOUT_MS >= RESPONSE_TIMEOUT_MS) {
+  throw new Error(
+    `Invalid timeout config: FETCH_TIMEOUT_MS (${FETCH_TIMEOUT_MS}) must be less than RESPONSE_TIMEOUT_MS (${RESPONSE_TIMEOUT_MS})`,
+  );
+}


### PR DESCRIPTION
## Summary

- `FETCH_TIMEOUT` and `RESPONSE_TIMEOUT` were both 10s, causing them to fire simultaneously when an upstream host is unreachable (e.g. a stale IP in item metadata). The AbortSignal would throw and `sendError(404)` would run at the same instant `res.setTimeout` sent a 504, producing `ERR_HTTP_HEADERS_SENT` errors and 504 responses visible to users.
- Reduces `FETCH_TIMEOUT` from 10s to 5s so the 404 error path always completes well before the 10s Express response timeout fires.
- Also replaces `new Date().getTime()` with `Date.now()` in `getCacheHeaders`.

## Context

Currently producing ~1,700 504s/day from items whose `object` URLs point to a stale IP (`67.111.179.146`) that no longer responds — these hang for the full timeout before failing. This fix ensures they fail fast with a 404 rather than racing into a 504.

## Test plan

- [ ] All 90 existing unit tests pass
- [ ] Verify in logs after deploy: no more `ERR_HTTP_HEADERS_SENT` errors; hung-upstream items return 404 within ~5s instead of 504 after 10s

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance & Infrastructure**
  * Centralized timeouts: request 3s, fetch 5s, response 10s for consistent behavior.
  * Runtime validation prevents an invalid timeout configuration (fetch >= response).
  * More reliable current-time usage when building Expires header; Cache-Control behavior unchanged.

* **Bug Fixes**
  * Safer timeout handling in response routes: no 504 sent after response has started or ended, and connections are properly closed when headers were already sent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->