### PR TITLE
chore: update DEPLOY.md — deploy-api-services now in dpla/api

### DIFF
--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -14,7 +14,7 @@ When deploying both the thumbnail API and the DPLA API in the same maintenance w
 ~/bin/deploy-api-services api      # api only
 ```
 
-The script lives at `~/bin/deploy-api-services` on the operator's local machine. If it's missing, ask in #tech or check with the person who last deployed.
+The script lives at `bin/deploy-api-services` in the `dpla/api` repository. Copy it to `~/bin/` on the deploy machine: `cp bin/deploy-api-services ~/bin/ && chmod +x ~/bin/deploy-api-services`. If it is missing from the deploy machine, check the repo.
 
 ---
 


### PR DESCRIPTION
## Summary

- Updates `DEPLOY.md` reference for `deploy-api-services`: the script now lives at `bin/deploy-api-services` in the `dpla/api` repository (see dpla/api#new PR)
- Replaces "ask in #tech" with an actionable copy command

## Test plan

- [ ] Verify the copy command works: `cp bin/deploy-api-services ~/bin/ && chmod +x ~/bin/deploy-api-services` (run from dpla/api repo)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

Updates `DEPLOY.md` to reflect that the `deploy-api-services` script is now located in the `dpla/api` repository at `bin/deploy-api-services`. The documentation now provides explicit instructions to copy and make the script executable (`cp bin/deploy-api-services ~/bin/ && chmod +x ~/bin/deploy-api-services`), replacing the previous guidance to "ask in #tech" if the script is not available.

**Changes:** Documentation-only update to `DEPLOY.md` (+1/-1 lines)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->