### PR TITLE
fix: release upstream response body before sending error on status/header failure

### DIFF
--- a/src/ThumbnailApi.ts
+++ b/src/ThumbnailApi.ts
@@ -98,6 +98,7 @@ export class ThumbnailApi {
 
     if (!this.responseHelper.okStatus(status)) {
       const error = new Error(`Status ${String(status)} from upstream.`);
+      remoteImageResponse.body?.cancel?.().catch(() => {});
       this.sendError(expressResponse, itemId, 404, error);
       return;
     }
@@ -106,6 +107,7 @@ export class ThumbnailApi {
 
     if (!this.responseHelper.okHeaders(remoteImageResponse.headers)) {
       const error = new Error(`Got bad headers from upstream.`);
+      remoteImageResponse.body?.cancel?.().catch(() => {});
       this.sendError(expressResponse, itemId, 404, error);
       return;
     }

--- a/src/ThumbnailApi.ts
+++ b/src/ThumbnailApi.ts
@@ -98,7 +98,7 @@ export class ThumbnailApi {
 
     if (!this.responseHelper.okStatus(status)) {
       const error = new Error(`Status ${String(status)} from upstream.`);
-      remoteImageResponse.body?.cancel?.().catch(() => {});
+      this.releaseUpstreamBody(remoteImageResponse);
       this.sendError(expressResponse, itemId, 404, error);
       return;
     }
@@ -107,7 +107,7 @@ export class ThumbnailApi {
 
     if (!this.responseHelper.okHeaders(remoteImageResponse.headers)) {
       const error = new Error(`Got bad headers from upstream.`);
-      remoteImageResponse.body?.cancel?.().catch(() => {});
+      this.releaseUpstreamBody(remoteImageResponse);
       this.sendError(expressResponse, itemId, 404, error);
       return;
     }
@@ -169,6 +169,10 @@ export class ThumbnailApi {
     } else {
       return undefined;
     }
+  }
+
+  private releaseUpstreamBody(response: Response): void {
+    void response.body?.cancel?.().catch(() => {});
   }
 
   sendError(

--- a/src/ThumbnailApi.ts
+++ b/src/ThumbnailApi.ts
@@ -141,6 +141,7 @@ export class ThumbnailApi {
 
     if (!this.responseHelper.okStatus(status)) {
       const error = new Error(`Status ${String(status)} from upstream.`);
+      this.releaseUpstreamBody(response);
       this.sendError(expressResponse, itemId, 404, error);
       return;
     }

--- a/src/ThumbnailApi.ts
+++ b/src/ThumbnailApi.ts
@@ -172,7 +172,7 @@ export class ThumbnailApi {
   }
 
   private releaseUpstreamBody(response: Response): void {
-    void response.body?.cancel?.().catch(() => {});
+    void response.body?.cancel?.()?.catch(() => {});
   }
 
   sendError(


### PR DESCRIPTION
## Summary

- Cancel the upstream response body (fire-and-forget) when `okStatus` or `okHeaders` checks fail, so the connection is released back to the pool even on error paths
- The cancel is intentionally not awaited — there's no need to block `sendError()` on it, and this avoids adding latency to the 404 error response

## Test plan

- [ ] Request an image whose upstream returns a non-200 ok response (e.g. 201) — verify the 404 is returned promptly
- [ ] Request an image whose upstream returns a bad Content-Type — verify the 404 is returned promptly
- [ ] Verify no connection pool exhaustion under concurrent load (connections returned after error paths)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This PR ensures upstream response bodies are explicitly cancelled when status or header validation fail in the image proxy flow so the underlying connection is released back to the pool. A new private helper releaseUpstreamBody(response: Response) is added; it calls response.body?.cancel?.()?.catch(() => {}) and is invoked (fire-and-forget, intentionally not awaited) on failure paths where translated upstream status is not okStatus and where okHeaders validation fails. The S3-serving path's translated-status failure branch was also updated to cancel the upstream response body.

The cancellation is deliberately not awaited to avoid adding latency to error responses (e.g., prompt 404s).

## Changes
- Modified file: src/ThumbnailApi.ts — added private helper releaseUpstreamBody and calls on status/header failure paths. (+7/-0)
- Nature of change: Bug fix addressing connection pool resource management on error paths

## Impact Assessment
- No manual pipeline trigger or ECS redeployment required beyond a normal deployment of the updated service image.
- No environment variables or AWS Secrets Manager keys added, removed, or renamed.
- No database migrations.
- No changes to shared infrastructure (CodePipeline, CodeBuild, ECS task definitions, IAM policies).
- No modifications to public-facing API response shapes or endpoints.
- No security implications introduced by this change.

## Test Plan
- Request an image whose upstream returns a non-200 translated status (e.g., 201) — verify a prompt 404 is returned.
- Request an image whose upstream returns a bad Content-Type — verify a prompt 404 is returned.
- Verify no connection pool exhaustion under concurrent load (connections returned after error paths).

Notes:
- PR description indicates it was generated with Claude Code.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->