### PR TITLE
Potential fixes for 5 code quality findings

### DIFF
--- a/src/ThumbnailApi.ts
+++ b/src/ThumbnailApi.ts
@@ -103,8 +103,6 @@ export class ThumbnailApi {
       return;
     }
 
-    expressResponse.status(status);
-
     if (!this.responseHelper.okHeaders(remoteImageResponse.headers)) {
       const error = new Error(`Got bad headers from upstream.`);
       this.releaseUpstreamBody(remoteImageResponse);
@@ -121,6 +119,8 @@ export class ThumbnailApi {
       this.sendError(expressResponse, itemId, 502, error);
       return;
     }
+
+    expressResponse.status(status);
 
     await this.responseHelper.pipe(
       remoteImageResponse.body as ReadableStream,

--- a/src/ThumbnailApi.ts
+++ b/src/ThumbnailApi.ts
@@ -201,6 +201,10 @@ export class ThumbnailApi {
     code: number,
     error?: Error,
   ): void {
+    if (res.headersSent) {
+      this.logger.error("Unable to send %s for %s: headers already sent", code, itemId, error);
+      return;
+    }
     if (error) {
       this.logger.error("Sending %s for %s:", code, itemId, error);
     }

--- a/src/ThumbnailApi.ts
+++ b/src/ThumbnailApi.ts
@@ -147,9 +147,18 @@ export class ThumbnailApi {
     }
 
     expressResponse.status(status);
-    expressResponse.set(
-      this.responseHelper.getHeadersFromTarget(response.headers),
-    );
+    try {
+      expressResponse.set(
+        this.responseHelper.getHeadersFromTarget(response.headers),
+      );
+    } catch (err) {
+      this.releaseUpstreamBody(response);
+      const error = err instanceof Error
+        ? err
+        : new Error("Failed to set upstream headers.");
+      this.sendError(expressResponse, itemId, 502, error);
+      return;
+    }
     if (this.responseHelper.okBody(response.body)) {
       await this.responseHelper.pipe(
         response.body as ReadableStream,

--- a/src/ThumbnailApi.ts
+++ b/src/ThumbnailApi.ts
@@ -52,7 +52,7 @@ export class ThumbnailApi {
     itemId: string,
     expressResponse: express.Response,
   ): Promise<void> {
-    let imageUrl = undefined;
+    let imageUrl: string | undefined;
 
     try {
       imageUrl = await this.dplaApi.getThumbnailUrl(itemId);

--- a/src/ThumbnailApi.ts
+++ b/src/ThumbnailApi.ts
@@ -155,7 +155,6 @@ export class ThumbnailApi {
       return;
     }
 
-    expressResponse.status(status);
     try {
       expressResponse.set(
         this.responseHelper.getHeadersFromTarget(response.headers),
@@ -168,6 +167,7 @@ export class ThumbnailApi {
       this.sendError(expressResponse, itemId, 502, error);
       return;
     }
+    expressResponse.status(status);
     if (this.responseHelper.okBody(response.body)) {
       await this.responseHelper.pipe(
         response.body as ReadableStream,

--- a/src/ThumbnailApi.ts
+++ b/src/ThumbnailApi.ts
@@ -8,7 +8,7 @@ import { getLogger } from "./logger";
 import { Logger } from "winston";
 
 const LONG_CACHE_TIME: number = 60 * 60 * 24 * 30; // 30 days in seconds
-const SHORT_CACHE_TIME = 60 * 60; // 1 hr in seconds
+const SHORT_CACHE_TIME: number = 60 * 60; // 1 hr in seconds
 const PATH_PATTERN = /^\/thumb\/([a-f0-9]{32})$/;
 
 export class ThumbnailApi {

--- a/src/ThumbnailApi.ts
+++ b/src/ThumbnailApi.ts
@@ -79,7 +79,7 @@ export class ThumbnailApi {
     // for a short amount because it won't have been sized down
     expressResponse.set(this.responseHelper.getCacheHeaders(SHORT_CACHE_TIME));
 
-    let remoteImageResponse: Response | undefined = undefined;
+    let remoteImageResponse: Response | undefined;
 
     try {
       remoteImageResponse =

--- a/src/ThumbnailApi.ts
+++ b/src/ThumbnailApi.ts
@@ -110,12 +110,21 @@ export class ThumbnailApi {
       return;
     }
 
-    expressResponse.set(
-      this.responseHelper.getHeadersFromTarget(remoteImageResponse.headers),
-    );
+    try {
+      expressResponse.set(
+        this.responseHelper.getHeadersFromTarget(remoteImageResponse.headers),
+      );
+    } catch (err) {
+      this.releaseUpstreamBody(remoteImageResponse);
+      const error =
+        err instanceof Error ? err : new Error("Failed to set upstream headers.");
+      this.sendError(expressResponse, itemId, 502, error);
+      return;
+    }
 
     if (!this.responseHelper.okBody(remoteImageResponse.body)) {
       const error = new Error("Received no body from upstream.");
+      this.releaseUpstreamBody(remoteImageResponse);
       this.sendError(expressResponse, itemId, 502, error);
       return;
     }
@@ -166,6 +175,7 @@ export class ThumbnailApi {
       );
     } else {
       const error = new Error("Upstream response had no body.");
+      this.releaseUpstreamBody(response);
       this.sendError(expressResponse, itemId, 502, error);
     }
   }


### PR DESCRIPTION
_This PR applies 5/5 suggestions from code quality [AI findings](https://github.com/dpla/thumbnail-api/security/quality/ai-findings)._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This PR applies 5 automated code-quality fixes in src/ThumbnailApi.ts to harden error handling and resource cleanup in the thumbnail proxy service. Key behavioral changes: header-setting is now guarded with try/catch and the upstream body is always released on error; response status is set only after header/body validation succeeds; and sendError() now no-ops (logs and returns) if headers were already sent to avoid ERR_HTTP_HEADERS_SENT.

Notable edits:
- Centralized headers-sent guard inside sendError(): if res.headersSent is true, sendError logs and returns instead of attempting to modify headers/body.
- Wrapped expressResponse.set(getHeadersFromTarget(...)) in try/catch in both proxyItemFromContributor() and serveItemFromS3(); on exception the upstream body is released and a 502 is returned.
- Moved expressResponse.status(status) to occur only after upstream header/body validation succeeds.
- Ensured releaseUpstreamBody(...) is called in previously unguarded error paths (including okBody-false branches) to prevent connection-pool/resource leaks.
- Added explicit TypeScript typings: const SHORT_CACHE_TIME: number; imageUrl typed as string | undefined; and an explicit declaration for remoteImageResponse.

Lines changed: +34 / -11. Estimated review effort: High.

## Changes

- Try/catch guards around header-setting and safe handling of header-setting failures in both proxy flows.
- Upstream body is released before returning error responses in all error branches.
- sendError strengthened to avoid attempts to send responses after headers are committed.
- Minor TypeScript typing improvements (SHORT_CACHE_TIME, imageUrl, remoteImageResponse).
- No public API endpoints or response shapes were intentionally changed; status and header behavior for error responses is handled more defensively.

## Security Implications

Improves resilience against resource-exhaustion and related denial-of-service vectors by ensuring upstream response bodies are always released and by preventing duplicate header/response writes. No authentication or credential handling changes were introduced.

## Pipeline / Infra / Migrations

- No manual pipeline trigger or ECS redeployment required beyond a normal deployment.
- No environment variable or AWS Secrets Manager key additions/removals.
- No database migrations.
- No changes to shared infrastructure (CodePipeline, CodeBuild, ECS task defs, IAM).
- No public API endpoint additions/removals; response-shape changes were limited to defensive error handling.

## Other Notes

- Changes are limited to src/ThumbnailApi.ts on branch ai-findings-autofix/src-ThumbnailApi.ts.
- Commit message highlights moving status() after headers are validated and centralizing the headers-sent guard to avoid ERR_HTTP_HEADERS_SENT.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->