### PR TITLE
Fix minor code quality issues (AI findings)

### DIFF
--- a/src/ThumbnailApi.ts
+++ b/src/ThumbnailApi.ts
@@ -192,7 +192,7 @@ export class ThumbnailApi {
   }
 
   private releaseUpstreamBody(response: Response): void {
-    void response.body?.cancel?.().catch(() => {});
+    void response.body?.cancel().catch((_err: unknown) => void _err);
   }
 
   sendError(

--- a/src/ThumbnailApi.ts
+++ b/src/ThumbnailApi.ts
@@ -76,7 +76,7 @@ export class ThumbnailApi {
       });
 
     // we only want the cache to have the proxied image from the contributor
-    // for a short amount because it won't have been sized down
+    // for a short amount of time because it won't have been sized down
     expressResponse.set(this.responseHelper.getCacheHeaders(SHORT_CACHE_TIME));
 
     let remoteImageResponse: Response | undefined;
@@ -192,7 +192,7 @@ export class ThumbnailApi {
   }
 
   private releaseUpstreamBody(response: Response): void {
-    void response.body?.cancel?.()?.catch(() => {});
+    void response.body?.cancel?.().catch(() => {});
   }
 
   sendError(


### PR DESCRIPTION
## Summary

Two minor fixes from GitHub AI code quality findings in `src/ThumbnailApi.ts`:

- **Line 79**: Complete the comment — "for a short amount" → "for a short amount of time"
- **Line 195**: Fix incorrect optional chaining on Promise — `cancel()?.catch` → `cancel().catch`. `cancel()` returns a `Promise`, not an object with properties, so `?.catch` would silently drop the error handler if `cancel()` is defined

## Test plan

- [ ] Existing tests pass (no logic changed, only comment text and one operator)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This PR makes two minor code-quality edits in src/ThumbnailApi.ts:

1. Comment clarification (around proxyItemFromContributor): completed the inline cache-duration comment to read that the proxied thumbnail is cached “for a short amount of time because it won't have been sized down”, improving clarity about the caching rationale.

2. Promise error-handling fix (releaseUpstreamBody): adjusted the cancel call on the upstream response body to ensure the returned Promise's catch handler is invoked. The code now calls response.body?.cancel().catch(...) (removing the incorrect optional-call style that could suppress the catch).

No logic or behavioral changes beyond these fixes.

## Impact Assessment

- No changes to public API shapes or endpoints
- No environment variables, AWS Secrets, or infrastructure (CodePipeline/CodeBuild/ECS/IAM) changes
- No database migrations
- No deployment or pipeline manual triggers required
- No security implications

Tests: existing test suite should continue to validate behavior; no new tests added.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dpla/thumbnail-api/pull/30)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->