### PR TITLE
Fix: Headers not forwarded to clients, incorrect Content-Type

### DIFF
--- a/src/ResponseHelper.ts
+++ b/src/ResponseHelper.ts
@@ -40,23 +40,19 @@ export class ResponseHelper {
   }
 
   //providers/s3 could set all sorts of weird headers, but we only want to pass along a few
-  getHeadersFromTarget(headers: Headers): Map<string, string> {
-    const result = new Map<string, string>();
+  getHeadersFromTarget(headers: Headers): Record<string, string> {
+    const result: Record<string, string> = {};
 
-    const addHeader = (
-      result: Map<string, string>,
-      headers: Headers,
-      header: string,
-    ) => {
+    const addHeader = (header: string) => {
       const value = headers.get(header);
-      if (value) {
-        result.set(header, value);
+
+      if (value !== null) {
+        result[header] = value;
       }
     };
 
-    // Reduce headers to just those that we want to pass through
-    addHeader(result, headers, "Content-Type");
-    addHeader(result, headers, "Last-Modified");
+    addHeader("Content-Type");
+    addHeader("Last-Modified");
 
     return result;
   }

--- a/src/ThumbnailApi.ts
+++ b/src/ThumbnailApi.ts
@@ -156,9 +156,13 @@ export class ThumbnailApi {
     }
 
     try {
-      expressResponse.set(
-        this.responseHelper.getHeadersFromTarget(response.headers),
-      );
+      const headers = this.responseHelper.getHeadersFromTarget(response.headers);
+      // All thumbnails in S3 are stored as .jpg,
+      // but may not be stored with the correct content type,
+      // causing S3 to return application/octet-stream as the default value.
+      // This overrides the Content-Type to ensure clients always receive type image/jpeg.
+      headers["Content-Type"] = "image/jpeg";
+      expressResponse.set(headers);
     } catch (err) {
       this.releaseUpstreamBody(response);
       const error = err instanceof Error

--- a/test/unit/ResponseHelper.test.ts
+++ b/test/unit/ResponseHelper.test.ts
@@ -16,9 +16,9 @@ describe("ResponseHelper", () => {
       ["foo", "bar"],
     ]);
     const result = responseHelper.getHeadersFromTarget(headers);
-    expect(result.get("Content-Type")).toBe("image/jpeg");
-    expect(result.get("Last-Modified")).toBe("2");
-    expect(result.get("foo")).toBeUndefined();
+    expect(result["Content-Type"]).toBe("image/jpeg");
+    expect(result["Last-Modified"]).toBe("2");
+    expect(result["foo"]).toBeUndefined();
   });
 
   test.each([

--- a/test/unit/ThumbnailApi.test.ts
+++ b/test/unit/ThumbnailApi.test.ts
@@ -119,7 +119,7 @@ describe("ThumbnailApi async tests", () => {
 
   responseHelper.getHeadersFromTarget = (headers: Headers) => {
     expect(headers).toBeDefined();
-    return new Map([["content-type", "image/jpeg"]]);
+    return { "content-type": "image/jpeg" };
   };
 
   const mockPipe = jest.fn();
@@ -160,7 +160,7 @@ describe("ThumbnailApi async tests", () => {
         status: 200,
       } as Response),
     );
-    responseHelper.getHeadersFromTarget = jest.fn(() => new Map());
+    responseHelper.getHeadersFromTarget = jest.fn(() => ({}));
     responseHelper.translateStatusCode = jest.fn(() => 200);
     responseHelper.okBody = okBody;
 
@@ -206,7 +206,7 @@ describe("ThumbnailApi async tests", () => {
       } as Response),
     );
     responseHelper.getHeadersFromTarget = jest.fn(
-      () => new Map([["content-type", "image/jpeg"]]),
+      () => ({ "content-type": "image/jpeg" }),
     );
     responseHelper.translateStatusCode = jest.fn(() => 200);
     responseHelper.okBody = okBody;
@@ -396,7 +396,7 @@ describe("ThumbnailApi async tests", () => {
 
     responseHelper.getHeadersFromTarget = (headers: Headers) => {
       expect(headers).toBeDefined();
-      return new Map([["content-type", "image/jpeg"]]);
+      return { "content-type": "image/jpeg" };
     };
 
     const okStatus = jest.fn(() => false);


### PR DESCRIPTION
This PR resolves two issues related to incorrect thumbnail headers.

## Header Forwarding
When opening a thumbnail (`dp.la/thumb/...`), I noticed that the browser prompts me to download the file instead of displaying it. Looking closer, I noticed the thumbnails are missing a `Content-Type` header (which is one of the two headers we intend to send alongside `Last-Modified`).

`ResponseHelper.getHeadersFromTarget` was returning a `Map<string, string>`, but Express's `res.set()` requires a plain object. Passing a Map caused `Object.keys()` to return an empty array, so no headers were ever set on the response. So our intended `Content-Type` and `Last-Modified` headers would be dropped.

This is fixed by changing `getHeadersFromTarget` to return `Record<string, string>` instead of `Map<string, string>`. I've also updated the corresponding tests, which masked the issue because they called `.get()` directly on the returned Map (which works), and the ThumbnailApi tests used a jest-express mock for `res.set()` that doesn't enforce Express's plain-object requirement.

## Incorrect Content-Type
With the above fix, our thumbnail API started providing `Content-Type`, but it was `application/octet-stream` instead of `image/jpeg`. The issue is that our thumbnails are stored in S3 without `ContentType` set, so they default to `application/octet-stream`. I've opened a PR in our thumbnailer lambda to fix this: https://github.com/dpla/thumbnailer-lambda/pull/12

As a stopgap, this PR overrides the `Content-Type` from S3 with value `image/jpeg`.

## Testing

Thumbnail headers before:
```
HTTP/1.1 200 OK
Date: Sat, 09 May 2026 03:06:49 GMT
Connection: keep-alive
Keep-Alive: timeout=5
Transfer-Encoding: chunked
```

Thumbnail headers after:
```
HTTP/1.1 200 OK
Content-Type: image/jpeg
Last-Modified: Wed, 20 Nov 2024 14:03:09 GMT
Date: Sat, 09 May 2026 03:05:05 GMT
Connection: keep-alive
Keep-Alive: timeout=5
Transfer-Encoding: chunked
```

# CodeRabbit Summary
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview
This PR fixes two header-related issues in the thumbnail API:

1. **Headers not being forwarded to clients**: `ResponseHelper.getHeadersFromTarget()` was returning a `Map<string, string>`, but Express's `res.set()` requires a plain object. When passed a Map, Object.keys() returned an empty array, causing no headers to be set. The method now returns `Record<string, string>` instead.

2. **Incorrect Content-Type for S3 thumbnails**: Thumbnails stored in S3 lack ContentType metadata and S3 returns `application/octet-stream`. As a stopgap (pending a fix in the thumbnailer lambda), the API now overrides the S3-derived Content-Type to `image/jpeg` before responding to clients.

## Changes
- **ResponseHelper.ts**: Updated `getHeadersFromTarget()` to return a plain object instead of a Map, with logic refactored to build the object by copying only `Content-Type` and `Last-Modified` headers when present.
- **ThumbnailApi.ts**: `serveItemFromS3()` now explicitly sets Content-Type to `image/jpeg` before forwarding headers to the client.
- **Tests**: Updated unit tests for both files to reflect the return type change from Map to plain object, ensuring tests verify correct header presence.

## API Response Changes
This PR changes the public-facing API response by fixing header forwarding—responses will now include `Content-Type: image/jpeg` and `Last-Modified` headers that were previously not being sent to clients due to the Map/plain-object incompatibility bug.

## Notes
- The Content-Type override is marked as a temporary measure; a permanent fix depends on https://github.com/dpla/thumbnailer-lambda/pull/12.
- No environment variables, infrastructure configuration, database migrations, or new endpoints are included.
- No manual deployment steps or pipeline triggers are required beyond normal CI/CD processes.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dpla/thumbnail-api/pull/31)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->